### PR TITLE
Use full key for custom ignore headers

### DIFF
--- a/pcap_diff.py
+++ b/pcap_diff.py
@@ -132,6 +132,7 @@ def flatten(d, parent_key=''):
     items = []
     
     for k, v in d.items():
+        fullk = "%s_%s" % (parent_key, k)
         # No complete diff? Ignore checksum, ttl and time
         if not complete_diff and (k == "chksum" or k == "ttl" or k == "time"): 
             continue
@@ -153,7 +154,7 @@ def flatten(d, parent_key=''):
             continue
 
         # Ignore custom header field?
-        if ignore_header and k == ignore_header:
+        if ignore_header and fullk == ignore_header:
             continue
 
         new_key = parent_key + '_' + k if parent_key else k


### PR DESCRIPTION
Sometimes there is a name clash between different headers.
src could be a Ether src or IP src.
If we specify the full header, we avoid the clash.
This especially makes sense when combined with pull request #1.

Referencing the example there (cloned packet dump with 802.1q vlan tags and one ICMP seq modified):`
`./pcap_diff.py -i test_icmp_dot1q.pcap -i test_icmp_dot1q_mod.pcap -f ICMP_payload_fields_seq` results in:

```
Diffing packets
:::::::::::::::::
Found 0 different packets
```

again.
